### PR TITLE
Fix/camera preview/rotation and size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,8 @@
 ext {
     versionName = '0.13.2'
 
-    bintrayUser = System.getenv('BINTRAY_USER')
-    bintrayKey = System.getenv('BINTRAY_KEY')
-
     compileSdkVersion = 27
-    buildToolsVersion = '27.0.0'
+    buildToolsVersion = '27.0.3'
 
     minSdkVersion = 15
     targetSdkVersion = 27
@@ -18,19 +15,13 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
 
-apply plugin: 'com.jfrog.bintray'
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven { url 'https://maven.google.com' }
-        maven { url 'https://wonderkiln.bintray.com/snapshots' }
     }
-    apply plugin: 'com.jfrog.bintray'
-    apply plugin: 'com.github.dcendents.android-maven'
 }

--- a/camerakit-core/build.gradle
+++ b/camerakit-core/build.gradle
@@ -1,21 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionName rootProject.ext.versionName
-    }
-    lintOptions {
-        abortOnError false
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+        minSdkVersion 15
+        targetSdkVersion 27
+        versionName '0.13.2'
     }
     sourceSets {
         main.java.srcDirs += 'src/main/base'
@@ -26,46 +17,10 @@ android {
         main.java.srcDirs += 'src/main/utils'
         main.java.srcDirs += 'src/main/vision'
     }
-    externalNativeBuild {
-        cmake {
-            path 'src/main/CMakeLists.txt'
-        }
-    }
 }
 
 dependencies {
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.android.support:exifinterface:27.0.2'
     implementation 'com.google.android.gms:play-services-vision:11.6.2'
-}
-
-group = 'com.wonderkiln'
-version = rootProject.ext.versionName
-
-install {
-    repositories.mavenInstaller {
-        pom.project {
-            name 'CameraKit-Core-Android'
-            packaging 'aar'
-        }
-    }
-}
-
-bintray {
-    user = rootProject.ext.bintrayUser
-    key = rootProject.ext.bintrayKey
-    override = true
-    publish = true
-    configurations = ['archives']
-    pkg {
-        repo = 'snapshots'
-        name = 'CameraKit-Core-Android'
-        userOrg = 'wonderkiln'
-        vcsUrl = 'https://github.com/wonderkiln/CameraKit-Android.git'
-        version {
-            name = rootProject.ext.versionName
-            vcsTag = rootProject.ext.versionName
-            released = new Date()
-        }
-    }
 }

--- a/camerakit-core/build.gradle
+++ b/camerakit-core/build.gradle
@@ -24,3 +24,7 @@ dependencies {
     compile 'com.android.support:exifinterface:27.0.2'
     implementation 'com.google.android.gms:play-services-vision:11.6.2'
 }
+
+repositories {
+    google()
+}

--- a/camerakit-core/src/main/api16/com/wonderkiln/camerakit/Camera1.java
+++ b/camerakit-core/src/main/api16/com/wonderkiln/camerakit/Camera1.java
@@ -36,7 +36,7 @@ import static com.wonderkiln.camerakit.CameraKit.Constants.METHOD_STILL;
 @SuppressWarnings("deprecation")
 public class Camera1 extends CameraImpl {
 
-    private static final String TAG = Camera1.class.getSimpleName();
+    private static final String TAG = Camera1.class.getName();
 
     private static final int FOCUS_AREA_SIZE_DEFAULT = 300;
     private static final int FOCUS_METERING_AREA_WEIGHT_DEFAULT = 1000;
@@ -286,7 +286,7 @@ public class Camera1 extends CameraImpl {
             if (zoomFactor <= 1) {
                 mZoom = 1;
             } else {
-                mZoom= zoomFactor;
+                mZoom = zoomFactor;
             }
 
             if (mCameraParameters != null && mCameraParameters.isZoomSupported()) {
@@ -499,7 +499,8 @@ public class Camera1 extends CameraImpl {
     }
 
     @Override
-    void stopVideo() {
+    boolean stopVideo() {
+        boolean isVideoRecorded = false;
         synchronized (mCameraLock) {
             if (mRecording) {
                 File videoFile = getVideoFile();
@@ -510,8 +511,10 @@ public class Camera1 extends CameraImpl {
                         mVideoCallback.videoCaptured(videoFile);
                         mVideoCallback = null;
                     }
+                    isVideoRecorded = true;
                 } catch (RuntimeException e) {
                     videoFile.delete();
+                    Log.e(TAG, e.getMessage());
                 }
 
                 releaseMediaRecorder();
@@ -521,6 +524,7 @@ public class Camera1 extends CameraImpl {
             stop();
             start();
         }
+        return isVideoRecorded;
     }
 
     @Override
@@ -785,6 +789,7 @@ public class Camera1 extends CameraImpl {
     }
 
     private void adjustCameraParameters(int currentTry) {
+        boolean invertPreviewSizes = (mCameraInfo.orientation + mDeviceOrientation) % 180 == 90;
         boolean haveToReadjust = false;
         Camera.Parameters resolutionLess = mCamera.getParameters();
 
@@ -795,9 +800,12 @@ public class Camera1 extends CameraImpl {
                     mCameraParameters.getPreviewFormat()
             );
 
+            // Reverted changes in https://github.com/CameraKit/camerakit-android/commit/5875fded1b7bdac1bcc049fcc3accff4c0ac5cbf
+            // to fix preview getting stretched
+
             mCameraParameters.setPreviewSize(
-                    getPreviewResolution().getWidth(),
-                    getPreviewResolution().getHeight()
+                    invertPreviewSizes ? getPreviewResolution().getHeight() : getPreviewResolution().getWidth(),
+                    invertPreviewSizes ? getPreviewResolution().getWidth() : getPreviewResolution().getHeight()
             );
 
             try {

--- a/camerakit-core/src/main/base/com/wonderkiln/camerakit/CameraImpl.java
+++ b/camerakit-core/src/main/base/com/wonderkiln/camerakit/CameraImpl.java
@@ -46,7 +46,7 @@ abstract class CameraImpl {
         void videoCaptured(File file);
     }
 
-    abstract void stopVideo();
+    abstract boolean stopVideo();
 
     abstract Size getCaptureResolution();
     abstract Size getVideoResolution();

--- a/camerakit-core/src/main/base/com/wonderkiln/camerakit/SurfaceViewPreview.java
+++ b/camerakit-core/src/main/base/com/wonderkiln/camerakit/SurfaceViewPreview.java
@@ -34,6 +34,7 @@ public class SurfaceViewPreview extends PreviewImpl {
 
 
         mSurfaceView = mContainer.findViewById(R.id.surface_view);
+        mSurfaceView.setZOrderMediaOverlay(true);
 
         final SurfaceHolder holder = mSurfaceView.getHolder();
 

--- a/camerakit-core/src/main/java/com/wonderkiln/camerakit/CameraView.java
+++ b/camerakit-core/src/main/java/com/wonderkiln/camerakit/CameraView.java
@@ -1,15 +1,5 @@
 package com.wonderkiln.camerakit;
 
-import static com.wonderkiln.camerakit.CameraKit.Constants.FACING_BACK;
-import static com.wonderkiln.camerakit.CameraKit.Constants.FACING_FRONT;
-import static com.wonderkiln.camerakit.CameraKit.Constants.FLASH_AUTO;
-import static com.wonderkiln.camerakit.CameraKit.Constants.FLASH_OFF;
-import static com.wonderkiln.camerakit.CameraKit.Constants.FLASH_ON;
-import static com.wonderkiln.camerakit.CameraKit.Constants.FLASH_TORCH;
-import static com.wonderkiln.camerakit.CameraKit.Constants.PERMISSIONS_LAZY;
-import static com.wonderkiln.camerakit.CameraKit.Constants.PERMISSIONS_PICTURE;
-import static com.wonderkiln.camerakit.CameraKit.Constants.PERMISSIONS_STRICT;
-
 import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
@@ -37,6 +27,16 @@ import com.wonderkiln.camerakit.core.R;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.wonderkiln.camerakit.CameraKit.Constants.FACING_BACK;
+import static com.wonderkiln.camerakit.CameraKit.Constants.FACING_FRONT;
+import static com.wonderkiln.camerakit.CameraKit.Constants.FLASH_AUTO;
+import static com.wonderkiln.camerakit.CameraKit.Constants.FLASH_OFF;
+import static com.wonderkiln.camerakit.CameraKit.Constants.FLASH_ON;
+import static com.wonderkiln.camerakit.CameraKit.Constants.FLASH_TORCH;
+import static com.wonderkiln.camerakit.CameraKit.Constants.PERMISSIONS_LAZY;
+import static com.wonderkiln.camerakit.CameraKit.Constants.PERMISSIONS_PICTURE;
+import static com.wonderkiln.camerakit.CameraKit.Constants.PERMISSIONS_STRICT;
 
 public class CameraView extends CameraViewLayout {
 
@@ -77,6 +77,7 @@ public class CameraView extends CameraViewLayout {
     private boolean mLockVideoAspectRatio;
     private boolean mCropOutput;
     private boolean mDoubleTapToToggleFacing;
+    private boolean mDisableAutoRotate;
 
     private boolean mAdjustViewBounds;
 
@@ -122,6 +123,7 @@ public class CameraView extends CameraViewLayout {
                 mDoubleTapToToggleFacing = a.getBoolean(R.styleable.CameraView_ckDoubleTapToToggleFacing, CameraKit.Defaults.DEFAULT_DOUBLE_TAP_TO_TOGGLE_FACING);
                 mLockVideoAspectRatio = a.getBoolean(R.styleable.CameraView_ckLockVideoAspectRatio, false);
                 mAdjustViewBounds = a.getBoolean(R.styleable.CameraView_android_adjustViewBounds, CameraKit.Defaults.DEFAULT_ADJUST_VIEW_BOUNDS);
+                mDisableAutoRotate = a.getBoolean(R.styleable.CameraView_ckDisableAutoRotate, false);
             } finally {
                 a.recycle();
             }
@@ -156,6 +158,9 @@ public class CameraView extends CameraViewLayout {
             mDisplayOrientationDetector = new DisplayOrientationDetector(context) {
                 @Override
                 public void onDisplayOrDeviceOrientationChanged(int displayOrientation, int deviceOrientation) {
+                    if (mDisableAutoRotate) {
+                        return;
+                    }
                     mCameraImpl.setDisplayAndDeviceOrientation(displayOrientation, deviceOrientation);
                     mPreviewImpl.setDisplayOrientation(displayOrientation);
                 }
@@ -497,8 +502,8 @@ public class CameraView extends CameraViewLayout {
         });
     }
 
-    public void stopVideo() {
-        mCameraImpl.stopVideo();
+    public boolean stopVideo() {
+        return mCameraImpl.stopVideo();
     }
 
     public Size getPreviewSize() {

--- a/camerakit-core/src/main/res/values/attrs.xml
+++ b/camerakit-core/src/main/res/values/attrs.xml
@@ -59,6 +59,8 @@
         <attr name="ckDoubleTapToToggleFacing" format="boolean" />
         <attr name="ckLockVideoAspectRatio" format="boolean" />
 
+        <attr name="ckDisableAutoRotate" format="boolean" />
+
         <attr name="android:adjustViewBounds" />
 
     </declare-styleable>

--- a/camerakit-vision/build.gradle
+++ b/camerakit-vision/build.gradle
@@ -1,21 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionName rootProject.ext.versionName
-    }
-    lintOptions {
-        abortOnError false
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+        minSdkVersion 15
+        targetSdkVersion 27
+        versionName '0.13.2'
     }
 }
 
@@ -23,35 +14,3 @@ dependencies {
     api project(':camerakit-core')
     implementation 'com.google.android.gms:play-services-vision:11.6.2'
 }
-
-group = 'com.wonderkiln'
-version = rootProject.ext.versionName
-
-install {
-    repositories.mavenInstaller {
-        pom.project {
-            name 'CameraKit-Vision-Android'
-            packaging 'aar'
-        }
-    }
-}
-
-bintray {
-    user = rootProject.ext.bintrayUser
-    key = rootProject.ext.bintrayKey
-    override = true
-    publish = true
-    configurations = ['archives']
-    pkg {
-        repo = 'snapshots'
-        name = 'CameraKit-Vision-Android'
-        userOrg = 'wonderkiln'
-        vcsUrl = 'https://github.com/wonderkiln/CameraKit-Android.git'
-        version {
-            name = rootProject.ext.versionName
-            vcsTag = rootProject.ext.versionName
-            released = new Date()
-        }
-    }
-}
-

--- a/camerakit/build.gradle
+++ b/camerakit/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionName rootProject.ext.versionName
+        minSdkVersion 15
+        targetSdkVersion 27
+        versionName '0.13.2'
     }
     lintOptions {
         abortOnError false
@@ -22,35 +22,4 @@ android {
 dependencies {
     compile project(':camerakit-core')
     compile project(':camerakit-vision')
-}
-
-group = 'com.wonderkiln'
-version = rootProject.ext.versionName
-
-install {
-    repositories.mavenInstaller {
-        pom.project {
-            name 'CameraKit-Android'
-            packaging 'aar'
-        }
-    }
-}
-
-bintray {
-    user = rootProject.ext.bintrayUser
-    key = rootProject.ext.bintrayKey
-    override = true
-    publish = true
-    configurations = ['archives']
-    pkg {
-        repo = 'snapshots'
-        name = 'CameraKit-Android'
-        userOrg = 'wonderkiln'
-        vcsUrl = 'https://github.com/wonderkiln/CameraKit-Android.git'
-        version {
-            name = rootProject.ext.versionName
-            vcsTag = rootProject.ext.versionName
-            released = new Date()
-        }
-    }
 }


### PR DESCRIPTION
### Updates
- Edited gradle files to allow building in Android Studio

#### Camera1.java
- Fix camera preview getting stretched ([cause](https://github.com/CameraKit/camerakit-android/commit/5875fded1b7bdac1bcc049fcc3accff4c0ac5cbf) as described in  CameraKit issue 288)
- Make `stopVideo()` return `true` on successful video record

#### SurfaceViewPreview.java
- Add `mSurfaceView.setZOrderMediaOverlay(true);` to make camera preview appear on top of other SurfaceViews (like videos)

#### CameraView.java and attrs.xml
- Added `ckDisableAutoRotate` option to disable orientation change events and fix the preview to portrait