### PR TITLE
Add ready events for camera and preview

### DIFF
--- a/camerakit-core/src/main/api16/com/wonderkiln/camerakit/Camera1.java
+++ b/camerakit-core/src/main/api16/com/wonderkiln/camerakit/Camera1.java
@@ -109,6 +109,7 @@ public class Camera1 extends CameraImpl {
                         mCamera.startPreview();
                         mShowingPreview = true;
                     }
+                    mEventDispatcher.dispatch(new CameraKitEvent(CameraKitEvent.TYPE_PREVIEW_READY));
                 }
             }
         });
@@ -128,6 +129,7 @@ public class Camera1 extends CameraImpl {
             mCamera.startPreview();
             mShowingPreview = true;
         }
+        mEventDispatcher.dispatch(new CameraKitEvent(CameraKitEvent.TYPE_CAMERA_READY));
     }
 
     @Override

--- a/camerakit-core/src/main/events/com/wonderkiln/camerakit/CameraKitEvent.java
+++ b/camerakit-core/src/main/events/com/wonderkiln/camerakit/CameraKitEvent.java
@@ -9,6 +9,7 @@ public class CameraKitEvent {
 
     public static final String TYPE_CAMERA_OPEN = "CKCameraOpenedEvent";
     public static final String TYPE_CAMERA_CLOSE = "CKCameraStoppedEvent";
+    public static final String TYPE_CAMERA_READY = "CKCameraReadyEvent";
 
     public static final String TYPE_FACING_CHANGED = "CKFacingChangedEvent";
     public static final String TYPE_FLASH_CHANGED = "CKFlashChangedEvent";
@@ -19,6 +20,8 @@ public class CameraKitEvent {
     public static final String TYPE_FOCUS_MOVED = "CKFocusMovedEvent";
 
     public static final String TYPE_TEXT_DETECTED = "CKTextDetectedEvent";
+
+    public static final String TYPE_PREVIEW_READY = "CKPreviewReadyEvent";
 
     private String type;
     private String message;


### PR DESCRIPTION
- Additional events `TYPE_CAMERA_READY` and `TYPE_PREVIEW_READY` used to check camera status more accurately